### PR TITLE
Fix breaking changes for array interop in Blazor

### DIFF
--- a/FFmpegBlazor/FFMPEG.cs
+++ b/FFmpegBlazor/FFMPEG.cs
@@ -58,16 +58,13 @@ namespace FFmpegBlazor
                 Hash = Hash,
                 Path = path
             });
-
-            await Task.Delay(1);
-
-            var length = reference.InvokeUnmarshalled<FileConf, int>("readFileLength", new() { Hash = Hash });
-            var array = new byte[length];
-
-            reference.InvokeUnmarshalled<FileConf, byte[], object>("readFileProcess", new() { Hash = Hash }, array);
-            
+          
+            await Task.Delay(5);
+           
+            var array =reference.Invoke<byte[]>("readFileProcess",Hash);
             return array;
         }
+
         /// <summary>
         /// Write buffer of C# to WASM in-memory File so that FFmpeg can interact 
         /// </summary>

--- a/FFmpegBlazor/FFMPEG.cs
+++ b/FFmpegBlazor/FFMPEG.cs
@@ -64,7 +64,6 @@ namespace FFmpegBlazor
             var array =reference.Invoke<byte[]>("readFileProcess",Hash);
             return array;
         }
-
         /// <summary>
         /// Write buffer of C# to WASM in-memory File so that FFmpeg can interact 
         /// </summary>

--- a/FFmpegBlazor/wwwroot/blazorFfmpeg.js
+++ b/FFmpegBlazor/wwwroot/blazorFfmpeg.js
@@ -40,12 +40,9 @@ window.FfmpegBlazorReference = () => {
             const h = Blazor.platform.readInt32Field(obj, 8);
             return readFileBuffers[h].byteLength;
         },
-        readFileProcess: (obj,buffer)=>
+        readFileProcess: (h)=>
         {
-            const h = Blazor.platform.readInt32Field(obj, 8);
-            let buff = Blazor.platform.toUint8Array(buffer);
-            buff.set(readFileBuffers[h]);
-            delete readFileBuffers[h];
+            return readFileBuffers[h];
         },
         writeFileFFmpeg: async (obj, buffer)=>{
             const contentArray = Blazor.platform.toUint8Array(buffer);


### PR DESCRIPTION
Aims to fix issue #10, where reading a file would return an empty array of bytes