### PR TITLE
fix deserialization error when using the CorePath parameter

### DIFF
--- a/FFmpegBlazor/FFMPEG.cs
+++ b/FFmpegBlazor/FFMPEG.cs
@@ -127,12 +127,12 @@ namespace FFmpegBlazor
         /// <summary>
         /// This Method is not intented for External Use
         /// </summary>
-        /// <param name="message"></param>
+        /// <param name="log"></param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [JSInvokable("logger")]
-        public void ZLoggerCallback(Logs message)
+        public void ZLoggerCallback(Logs log)
         {
-            Logger?.Invoke(message);
+            Logger?.Invoke(log);
         }
 
         /// <summary>

--- a/FFmpegBlazor/wwwroot/blazorFfmpeg.js
+++ b/FFmpegBlazor/wwwroot/blazorFfmpeg.js
@@ -19,7 +19,7 @@ window.FfmpegBlazorReference = () => {
                 ffmpegObjectInstances[hash] = FFmpeg.createFFmpeg({
                     corePath: config.corePath,
                     log: config.log,
-                    logger: ({ message }) => Dotnet.invokeMethodAsync("logger", message),
+                    logger: (message) => Dotnet.invokeMethodAsync("logger", message),
                     progress: (p) => Dotnet.invokeMethodAsync("progress", p)
                 });
 

--- a/FFmpegBlazor/wwwroot/blazorFfmpeg.js
+++ b/FFmpegBlazor/wwwroot/blazorFfmpeg.js
@@ -12,14 +12,14 @@ window.FfmpegBlazorReference = () => {
             if (config.corePath == null)
                 ffmpegObjectInstances[hash] = FFmpeg.createFFmpeg({
                     log: config.log,
-                    logger: (message) => Dotnet.invokeMethodAsync("logger", message),
+                    logger: (log) => Dotnet.invokeMethodAsync("logger", log),
                     progress: (p) => Dotnet.invokeMethodAsync("progress", p)
             });
             else
                 ffmpegObjectInstances[hash] = FFmpeg.createFFmpeg({
                     corePath: config.corePath,
                     log: config.log,
-                    logger: (message) => Dotnet.invokeMethodAsync("logger", message),
+                    logger: (log) => Dotnet.invokeMethodAsync("logger", log),
                     progress: (p) => Dotnet.invokeMethodAsync("progress", p)
                 });
 


### PR DESCRIPTION
Need to be able to use CorePath correctly because the ffmpeg.min.js you have tries to load the core from a relative path.